### PR TITLE
🗑️ Remove permission change for OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
 ARG BASE_VERSION=latest
 FROM ghcr.io/contrast-security-inc/contrast:$BASE_VERSION as base
 
-USER 0
-
-RUN chgrp -R 0 /opt/contrast \
-  && chmod -R g+rwX /opt/contrast
-
 EXPOSE 8080
 
 ENTRYPOINT [ "docker-entrypoint.sh" ]


### PR DESCRIPTION
Base image now works in OpenShift. This project is now only required to mirror from GHCR to Docker Hub.